### PR TITLE
`cdn_invalidate` helper that accepts a list of files

### DIFF
--- a/lib/middleman-cdn/commands.rb
+++ b/lib/middleman-cdn/commands.rb
@@ -23,7 +23,7 @@ module Middleman
       end
 
       desc "cdn:cdn_invalidate", "Invalidate your CloudFlare or CloudFront cache"
-      def cdn_invalidate(options = nil)
+      def cdn_invalidate(options = nil, files = nil)
         begin
           if options.nil?
             app_instance = ::Middleman::Application.server.inst
@@ -40,7 +40,7 @@ module Middleman
             raise
           end
 
-          files = normalize_files(list_files(options.filter))
+          files = normalize_files(files || list_files(options.filter))
           self.class.say_status(nil, "Invalidating #{files.count} files with filter: " + "#{options.filter.source}".magenta.bold)
           files.each { |file| self.class.say_status(nil, " • #{file}") }
           return if files.empty?

--- a/lib/middleman-cdn/commands.rb
+++ b/lib/middleman-cdn/commands.rb
@@ -40,7 +40,7 @@ module Middleman
             raise
           end
 
-          files = list_files(options.filter)
+          files = normalize_files(list_files(options.filter))
           self.class.say_status(nil, "Invalidating #{files.count} files with filter: " + "#{options.filter.source}".magenta.bold)
           files.each { |file| self.class.say_status(nil, " • #{file}") }
           return if files.empty?
@@ -100,20 +100,21 @@ end
 
             # Remove files that do not match filter
             files.reject! { |f| f !~ filter }
-
-            # Add directories of index.html files since they have to be
-            # invalidated as well if :directory_indexes is active
-            files.each do |file|
-              file_dir = file.sub(/\bindex\.html\z/, '')
-              files << file_dir if file_dir != file
-            end
-
-            # Add leading slash
-            files.map! { |f| f.start_with?('/') ? f : "/#{f}" }
           end
         end
       end
 
+      def normalize_files(files)
+        # Add directories of index.html files since they have to be
+        # invalidated as well if :directory_indexes is active
+        files.each do |file|
+          file_dir = file.sub(/\bindex\.html\z/, '')
+          files << file_dir if file_dir != file
+        end
+
+        # Add leading slash
+        files.map! { |f| f.start_with?('/') ? f : "/#{f}" }
+      end
     end
 
     Base.map({"cdn" => "cdn_invalidate"})

--- a/lib/middleman-cdn/extension.rb
+++ b/lib/middleman-cdn/extension.rb
@@ -3,6 +3,10 @@ require 'middleman-core'
 module Middleman
   module CDN
     module Helpers
+      def cdn_invalidate(files = nil)
+        ::Middleman::Cli::CDN.new.cdn_invalidate(cdn_options, files)
+      end
+
       def cdn_options
         ::Middleman::CDN::CDNExtension.options
       end
@@ -24,7 +28,7 @@ module Middleman
 
         app.after_configuration do
           app.after_build do
-            ::Middleman::Cli::CDN.new.cdn_invalidate(@@cdn_options) if @@cdn_options.after_build
+            cdn_invalidate if cdn_options.after_build
           end
         end
 

--- a/spec/lib/middleman-cdn/commands_spec.rb
+++ b/spec/lib/middleman-cdn/commands_spec.rb
@@ -112,5 +112,22 @@ describe Middleman::Cli::CDN do
         subject.cdn_invalidate(options)
       end
     end
+
+    context "list of files provided" do
+      let(:options) do
+        OpenStruct.new({
+          cloudflare: {},
+          cloudfront: {},
+          fastly: {}
+        })
+      end
+
+      it "should invalidate the files with all cdns" do
+        expect_any_instance_of(::Middleman::Cli::CloudFlareCDN).to receive(:invalidate).with(options.cloudflare, ["/index.html", "/"])
+        expect_any_instance_of(::Middleman::Cli::CloudFrontCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/"])
+        expect_any_instance_of(::Middleman::Cli::FastlyCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/"])
+        subject.cdn_invalidate(options, ["index.html"])
+      end
+    end
   end
 end


### PR DESCRIPTION
Is this something you'd want? I'm using it with an [`after_s3_sync`][middleman-s3_sync] hook in my `config.rb`:

```ruby
after_s3_sync do |files_by_status|
  cdn_invalidate files_by_status[:updated]
end
```

  [middleman-s3_sync]: https://github.com/fredjean/middleman-s3_sync