### PR TITLE
depend only on fog-aws, not all fog libs

### DIFF
--- a/lib/middleman-cdn/cdns/cloudfront.rb
+++ b/lib/middleman-cdn/cdns/cloudfront.rb
@@ -1,4 +1,4 @@
-require "fog"
+require "fog/aws"
 require "active_support/core_ext/string"
 
 module Middleman

--- a/middleman-cdn.gemspec
+++ b/middleman-cdn.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files -z`.split("\0")
   s.require_paths = ["lib"]
 
-  s.add_dependency 'fog', '~> 1.9'
+  s.add_dependency 'fog-aws', '~> 1.4'
   s.add_dependency 'cloudflare', '~> 2.0'
   s.add_dependency 'fastly', '~> 1.1'
   s.add_dependency 'maxcdn', '~> 0.1'


### PR DESCRIPTION
It's not necessary to depend on all (~30) Fog gems when we're just using Fog/AWS. 😄 