### PR TITLE
update ruby versions in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2
+  - 2.3
+  - 2.4
 before_install:
   - gem update --system
   - gem install bundler
@@ -15,7 +15,3 @@ gemfile:
   - gemfiles/middleman_4.1.gemfile
   - gemfiles/middleman_4.2.gemfile
   - gemfiles/middleman_master.gemfile
-matrix:
-  allow_failures:
-    - rvm: 2.4.0
-      gemfile: gemfiles/middleman_4.1.gemfile


### PR DESCRIPTION
Ruby 2.4.2 indeed doesn't have the problem with Middleman 4.1 that Ruby 2.4.0 has.