### PR TITLE
Updating activesupport dependency to 5.1

### DIFF
--- a/lib/middleman-cdn/cdns/cloudflare.rb
+++ b/lib/middleman-cdn/cdns/cloudflare.rb
@@ -39,7 +39,7 @@ module Middleman
           raise
         end
 
-        cloudflare = ::CloudFlare::connection(options[:client_api_key], options[:email])
+        cloudflare = ::Cloudflare::connection(options[:client_api_key], options[:email])
         if all || (options[:invalidate_zone_for_many_files] && files.count > INVALIDATE_ZONE_THRESHOLD)
           begin
             say_status("Invalidating zone #{options[:zone]}... ", newline: false)

--- a/middleman-cdn.gemspec
+++ b/middleman-cdn.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0.7'
   s.add_development_dependency 'appraisal', '~> 2.1'
 
-  s.add_dependency 'middleman', '~> 4.2'
+  s.add_dependency 'middleman', '>= 3.2'
 end

--- a/middleman-cdn.gemspec
+++ b/middleman-cdn.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'fastly', '~> 1.1'
   s.add_dependency 'maxcdn', '~> 0.1'
   s.add_dependency 'ansi', '~> 1.5'
-  s.add_dependency 'activesupport', '~> 4.1'
+  s.add_dependency 'activesupport', '=> 4.1'
   s.add_dependency 'httparty', '~> 0.13'
 
   s.add_development_dependency 'rake', '~> 0.9'

--- a/middleman-cdn.gemspec
+++ b/middleman-cdn.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'fog-aws', '~> 1.4'
-  s.add_dependency 'cloudflare', '~> 2.0'
+  s.add_dependency 'cloudflare', '~> 3.0'
   s.add_dependency 'fastly', '~> 1.1'
   s.add_dependency 'maxcdn', '~> 0.1'
   s.add_dependency 'ansi', '~> 1.5'
-  s.add_dependency 'activesupport', '=> 4.1'
+  s.add_dependency 'activesupport', '>= 4.1'
   s.add_dependency 'httparty', '~> 0.13'
 
   s.add_development_dependency 'rake', '~> 0.9'
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'coveralls', '~> 0.7'
   s.add_development_dependency 'appraisal', '~> 2.1'
 
-  s.add_dependency 'middleman', '>= 3.3'
+  s.add_dependency 'middleman', '~> 4.2'
 end

--- a/spec/lib/middleman-cdn/cdns/cloudflare_spec.rb
+++ b/spec/lib/middleman-cdn/cdns/cloudflare_spec.rb
@@ -52,7 +52,7 @@ describe Middleman::Cli::CloudFlareCDN do
 
     before do
       allow(double_cloudflare).to receive(:zone_file_purge)
-      allow(::CloudFlare).to receive(:connection).and_return(double_cloudflare)
+      allow(::Cloudflare).to receive(:connection).and_return(double_cloudflare)
     end
 
     let(:files) { (1..50).map { |i| "/test/file_#{i}.txt" } }
@@ -69,7 +69,7 @@ describe Middleman::Cli::CloudFlareCDN do
       end
 
       it "should connect to cloudflare with credentails" do
-        expect(::CloudFlare).to receive(:connection).with("000000000000000000000", "test@example.com")
+        expect(::Cloudflare).to receive(:connection).with("000000000000000000000", "test@example.com")
         subject.invalidate(options, files)
       end
 
@@ -166,7 +166,7 @@ describe Middleman::Cli::CloudFlareCDN do
       end
 
       it "should connect to cloudflare with environment variable credentails" do
-        expect(::CloudFlare).to receive(:connection).with("111111111111111111111", "test-env@example.com")
+        expect(::Cloudflare).to receive(:connection).with("111111111111111111111", "test-env@example.com")
         subject.invalidate(options, files)
       end
 


### PR DESCRIPTION
I wrote this when my dependency checker was complaining activesupport 4.1 was out of date.  

This updates active support to be `~> 5.1` and middleman to '~> 4.2'.