### PR TITLE
Invalidate directories without trailing slashes (Such as /blog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ It's better to always invalidate only the files you need. If you're using
 generate fingerprinted CSS, JS and images, then you should never need to
 invalidate them.
 
-Note: Directories containing `index.html` files are automatically included
-when their respective `index.html` is included in the filter.
+Note: Directories containing `index.html` files are automatically included when
+their respective `index.html` is included in the filter. Both the slashed and
+non-slashed version of the directory are invalidated. e.g. The file
+`/blog/index.html` will also invalidate `/blog/` and `/blog`.
 
 Alternatively: If you're using `middleman-s3_sync` you can hook middleman-cdn into 
 it's build process. See the [instructions here](#invalidating-with-middleman-s3_sync).

--- a/lib/middleman-cdn/commands.rb
+++ b/lib/middleman-cdn/commands.rb
@@ -48,6 +48,7 @@ module Middleman
             files = normalize_files(list_files(options.filter))
             message = "Invalidating #{files.count} files with filter: #{options.filter.source}"
           end
+
           self.class.say_status(nil, message)
           files.each { |file| self.class.say_status(nil, " • #{file}") }
 
@@ -121,13 +122,21 @@ end
       def normalize_files(files)
         # Add directories of index.html files since they have to be
         # invalidated as well if :directory_indexes is active
-        files.each do |file|
-          file_dir = file.sub(/\bindex\.html\z/, '')
-          files << file_dir if file_dir != file
-        end
+        files += files.collect do |file|
+          file.sub(/\bindex\.html\z/, '') if file.ends_with?('index.html')
+        end.compact
+
+        # Add directories without trailing slashes also, so if a user visited
+        # /blog it will still be invalidated.
+        files += files.collect do |file|
+          file.sub(/\/index\.html\z/, '') if file.ends_with?('/index.html')
+        end.compact
 
         # Add leading slash
         files.map! { |f| f.start_with?('/') ? f : "/#{f}" }
+
+        # Remove any duplicates
+        files.uniq
       end
 
       Base.register(self, 'cdn_invalidate', 'cdn_invalidate [options]', 'Invalidate CDN')

--- a/lib/middleman-cdn/commands.rb
+++ b/lib/middleman-cdn/commands.rb
@@ -48,7 +48,6 @@ module Middleman
             files = normalize_files(list_files(options.filter))
             message = "Invalidating #{files.count} files with filter: #{options.filter.source}"
           end
-
           self.class.say_status(nil, message)
           files.each { |file| self.class.say_status(nil, " • #{file}") }
 
@@ -122,21 +121,18 @@ end
       def normalize_files(files)
         # Add directories of index.html files since they have to be
         # invalidated as well if :directory_indexes is active
-        files += files.collect do |file|
-          file.sub(/\bindex\.html\z/, '') if file.ends_with?('index.html')
-        end.compact
+        files.each do |file|
+	  # For /dir/index.html add /dir/
+          file_dir = file.sub(/\bindex\.html\z/, '')
+          files << file_dir if file_dir != file
 
-        # Add directories without trailing slashes also, so if a user visited
-        # /blog it will still be invalidated.
-        files += files.collect do |file|
-          file.sub(/\/index\.html\z/, '') if file.ends_with?('/index.html')
-        end.compact
+	  # For /dir/index.html add /dir
+          file_dir_no_slash = file.sub(/\/index\.html\z/, '')
+          files << file_dir_no_slash if file_dir_no_slash != file
+        end
 
         # Add leading slash
         files.map! { |f| f.start_with?('/') ? f : "/#{f}" }
-
-        # Remove any duplicates
-        files.uniq
       end
 
       Base.register(self, 'cdn_invalidate', 'cdn_invalidate [options]', 'Invalidate CDN')

--- a/lib/middleman-cdn/commands.rb
+++ b/lib/middleman-cdn/commands.rb
@@ -122,11 +122,11 @@ end
         # Add directories of index.html files since they have to be
         # invalidated as well if :directory_indexes is active
         files.each do |file|
-	  # For /dir/index.html add /dir/
+          # For /dir/index.html add /dir/
           file_dir = file.sub(/\bindex\.html\z/, '')
           files << file_dir if file_dir != file
 
-	  # For /dir/index.html add /dir
+          # For /dir/index.html add /dir
           file_dir_no_slash = file.sub(/\/index\.html\z/, '')
           files << file_dir_no_slash if file_dir_no_slash != file
         end

--- a/spec/lib/middleman-cdn/commands_spec.rb
+++ b/spec/lib/middleman-cdn/commands_spec.rb
@@ -26,8 +26,9 @@ describe Middleman::Cli::CDN do
   describe '#cdn_invalidate' do
     before do
       allow(Dir).to receive(:chdir).with(anything) { |path, &block| block.call }
-      allow(Dir).to receive(:glob).with('**/*', File::FNM_DOTMATCH).and_return([".", "index.html", "image.png"])
+      allow(Dir).to receive(:glob).with('**/*', File::FNM_DOTMATCH).and_return([".", "index.html", "image.png", "blog/index.html"])
       allow(File).to receive(:directory?).with(".").and_return(true)
+      allow(File).to receive(:directory?).with("blog/index.html").and_return(false)
       allow(File).to receive(:directory?).with("index.html").and_return(false)
       allow(File).to receive(:directory?).with("image.png").and_return(false)
     end
@@ -57,7 +58,7 @@ describe Middleman::Cli::CDN do
         end
 
         it "should invalidate the files with only cloudflare" do
-          expect_any_instance_of(::Middleman::Cli::CloudFlareCDN).to receive(:invalidate).with(options.cloudflare, ["/index.html", "/image.png", "/"], all: true)
+          expect_any_instance_of(::Middleman::Cli::CloudFlareCDN).to receive(:invalidate).with(options.cloudflare, ["/index.html", "/image.png", "/blog/index.html", "/", "/blog/", "/blog"], all: true)
           expect_any_instance_of(::Middleman::Cli::CloudFrontCDN).to_not receive(:invalidate)
           expect_any_instance_of(::Middleman::Cli::FastlyCDN).to_not receive(:invalidate)
           subject.cdn_invalidate(options)
@@ -75,9 +76,9 @@ describe Middleman::Cli::CDN do
         end
 
         it "should invalidate the files with all cdns" do
-          expect_any_instance_of(::Middleman::Cli::CloudFlareCDN).to receive(:invalidate).with(options.cloudflare, ["/index.html", "/image.png", "/"], all: true)
-          expect_any_instance_of(::Middleman::Cli::CloudFrontCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/image.png", "/"], all: true)
-          expect_any_instance_of(::Middleman::Cli::FastlyCDN).to receive(:invalidate).with(options.fastly, ["/index.html", "/image.png", "/"], all: true)
+          expect_any_instance_of(::Middleman::Cli::CloudFlareCDN).to receive(:invalidate).with(options.cloudflare, ["/index.html", "/image.png", "/blog/index.html", "/", "/blog/", "/blog"], all: true)
+          expect_any_instance_of(::Middleman::Cli::CloudFrontCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/image.png", "/blog/index.html", "/", "/blog/", "/blog"], all: true)
+          expect_any_instance_of(::Middleman::Cli::FastlyCDN).to receive(:invalidate).with(options.fastly, ["/index.html", "/image.png", "/blog/index.html", "/", "/blog/", "/blog"], all: true)
           subject.cdn_invalidate(options)
         end
       end
@@ -94,9 +95,9 @@ describe Middleman::Cli::CDN do
       end
 
       it "should invalidate the files with all cdns" do
-        expect_any_instance_of(::Middleman::Cli::CloudFlareCDN).to receive(:invalidate).with(options.cloudflare, ["/index.html", "/"], all: false)
-        expect_any_instance_of(::Middleman::Cli::CloudFrontCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/"], all: false)
-        expect_any_instance_of(::Middleman::Cli::FastlyCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/"], all: false)
+        expect_any_instance_of(::Middleman::Cli::CloudFlareCDN).to receive(:invalidate).with(options.cloudflare, ["/index.html", "/blog/index.html", "/", "/blog/", "/blog"], all: false)
+        expect_any_instance_of(::Middleman::Cli::CloudFrontCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/blog/index.html", "/", "/blog/", "/blog"], all: false)
+        expect_any_instance_of(::Middleman::Cli::FastlyCDN).to receive(:invalidate).with(options.cloudfront, ["/index.html", "/blog/index.html", "/", "/blog/", "/blog"], all: false)
         subject.cdn_invalidate(options)
       end
     end


### PR DESCRIPTION
On my middleman setup I have the server configured so:

`/blog` will be loaded from `/blog/index.html`

This allows me to have more prettier URLs. 

Currently the extension would invalidate the paths:

```
/
/index.html
/blog/index.html
/blog/
```

This fix includes the paths without the trailing slashes for invalidation. So it will now invalidate:

```
/
/index.html
/blog/index.html
/blog/
/blog
```