### PR TITLE
Fix #17: Make the gem compatible with Cloudflare v3 gem

### DIFF
--- a/middleman-cdn.gemspec
+++ b/middleman-cdn.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'fog-aws', '~> 1.4'
-  s.add_dependency 'cloudflare', '~> 3.0'
+  s.add_dependency 'cloudflare', '~> 3.2.0'
   s.add_dependency 'fastly', '~> 1.1'
   s.add_dependency 'maxcdn', '~> 0.1'
   s.add_dependency 'ansi', '~> 1.5'

--- a/middleman-cdn.gemspec
+++ b/middleman-cdn.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'fog-aws', '~> 1.4'
-  s.add_dependency 'cloudflare', '~> 3.2.0'
+  s.add_dependency 'cloudflare', '~> 3.2.1'
   s.add_dependency 'fastly', '~> 1.1'
   s.add_dependency 'maxcdn', '~> 0.1'
   s.add_dependency 'ansi', '~> 1.5'

--- a/spec/lib/middleman-cdn/cdns/cloudflare_spec.rb
+++ b/spec/lib/middleman-cdn/cdns/cloudflare_spec.rb
@@ -56,13 +56,28 @@ describe Middleman::Cli::CloudFlareCDN do
       expect(cloudflare_module).to respond_to(:connect).with_keywords(:key, :email)
     end
 
-    context 'zone' do
+    context 'zones' do
       it "should have #zones method" do
         expect(cloudflare).to respond_to(:zones)
       end
 
       it "should have #zones.find_by_name method" do
         expect(cloudflare.zones).to respond_to(:find_by_name).with(1).argument
+      end
+    end
+
+    context 'zone' do
+      before(:each) do
+        allow(cloudflare_response).to receive(:result) { double }
+        allow_any_instance_of(zone_class).to receive(:get) { cloudflare_response }
+      end
+
+      let(:zone_class) { ::Cloudflare::Zone }
+      let(:zone) { zone_class.new('http://example.com') }
+      let(:cloudflare_response) { double }
+
+      it "should have #purge_cache method" do
+        expect(zone).to respond_to(:purge_cache)
       end
     end
   end


### PR DESCRIPTION
This PR fixes #17. But it requires new version of the `cloudflare` gem which is not released yet, because `purge_cache` method is missing in the new version of the `cloudflare` gem. See https://github.com/ioquatix/cloudflare/pull/31 for more info.

I've QA'd it with real API and it worked.